### PR TITLE
chore: ignore config directory in docker build

### DIFF
--- a/airflow/.dockerignore
+++ b/airflow/.dockerignore
@@ -5,3 +5,4 @@ __pycache__
 *.log
 tests/
 .DS_Store
+config/


### PR DESCRIPTION
Add the config directory to .dockerignore to prevent it from being included in the Docker build context.