### PR TITLE
feat(interview): dynamically set number of questions based on config

### DIFF
--- a/backend/interview_agent/src/interview_agent/graph.py
+++ b/backend/interview_agent/src/interview_agent/graph.py
@@ -74,7 +74,9 @@ async def generate_question(state: State, config: RunnableConfig):
         args=[str(sql_mcp_path)],
     )
     model = ChatOpenAI(model="gpt-4o-mini")
-    num_questions = 5
+    my_config = Configuration.from_runnable_config(config)
+    num_questions = my_config.number_of_questions
+
 
     def generate_question_message(job_description: str, num_questions: int):
         return f"You are an interviewer. You will be crafting questions for a phone interview using the tool 'sql_tool'. The tool is a database of interview questions and answers. Generate a list of {num_questions} possible interview questions based on the job description provided. \n Job Description: {job_description}"
@@ -114,7 +116,7 @@ async def wait_for_user_input(
     state: State, config: RunnableConfig
 ) -> Command[Literal["human_node", "wait_for_user_input_node"]]:
     """Wait for the user to start the interview."""
-    user_input = interrupt(WAIT_FOR_USER_INTERRUPT_MESSAGE)
+    user_input = interrupt(f"{len(state['qa_list'])}")
     if user_input == START_INTERVIEW:
         return Command(goto="human_node")
     else:

--- a/frontend/src/pages/JobDescriptionPage.tsx
+++ b/frontend/src/pages/JobDescriptionPage.tsx
@@ -15,25 +15,30 @@ export default function JobDescriptionPage() {
 
   const handleStart = async () => {
     if (!jobDescription.trim()) return;
-
+  
     setLoading(true);
     const threadId = uuidv4();
-
+  
     try {
       const res = await fetch(`${BACKEND_URL}/interview`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: jobDescription, thread_id: threadId })
       });
-
+  
       const data = await res.json();
-
+  
       if (
         typeof data?.message === "string" &&
         data.message.toLowerCase().includes("please provide a valid job description")
       ) {
         alert("Please provide a valid job description.");
       } else {
+        const questionCount = parseInt(data.message); // Make sure this is a number
+        console.log("Backend response:", data);
+        if (!isNaN(questionCount)) {
+          localStorage.setItem("n_questions", String(questionCount));
+        }
         localStorage.setItem("job_description", jobDescription);
         localStorage.setItem("thread_id", threadId);
         navigate("/interview", { state: { fromJobDescription: true } });

--- a/frontend/src/pages/MockInterview.tsx
+++ b/frontend/src/pages/MockInterview.tsx
@@ -28,6 +28,7 @@ export default function MockInterview() {
 
   const [jobDescription] = useState(() => localStorage.getItem("job_description") || "");
   const [threadId] = useState(() => localStorage.getItem("thread_id") || "");
+  const [nQuestions] = useState(() => parseInt(localStorage.getItem("n_questions") || "5"));
   const [questions, setQuestions] = useState<string[]>([]);
   const [responses, setResponses] = useState<string[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -69,6 +70,7 @@ export default function MockInterview() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message, thread_id: threadId }),
       });
+
       const data = await res.json();
 
       if (res.status === 418 || data.message === "Please provide a valid job description") {
@@ -77,16 +79,14 @@ export default function MockInterview() {
         return;
       }
 
-      if (data.feedback) {
-        setCompleted(true);
+      if (data.message === "Interview complete" && data.feedback) {
         setLoading(false);
+        setCompleted(true);
         setFeedbackList(data.feedback);
         return;
       }
 
-      if (!data.message || data.message === "Interview complete") return;
-
-      if (data.message !== questions[questions.length - 1]) {
+      if (data.message && data.message !== questions[questions.length - 1]) {
         setQuestions((prev) => [...prev, data.message]);
         setResponses((prev) => [...prev, ""]);
         setCurrentIndex((prev) => prev + 1);
@@ -119,7 +119,13 @@ export default function MockInterview() {
     setShowTextarea(false);
     hasPlayedRef.current = false;
     const responseToSend = responses[currentIndex - 1]?.trim() || "Skipped";
-    if (currentIndex === 5) setLoading(true);
+  
+    const isLastQuestion = currentIndex === nQuestions;
+  
+    if (isLastQuestion) {
+      setLoading(true);
+    }
+  
     fetchNext(responseToSend);
   };
 
@@ -173,19 +179,19 @@ export default function MockInterview() {
 
   const handleStopVoice = () => stopRecognition();
 
-  const restartInterview = () => {
-    setResponses([]);
-    setQuestions([]);
-    setCurrentIndex(0);
-    setShowTextarea(false);
-    setFeedbackList([]);
-    setCompleted(false);
-    setElapsedTime(0);
-    setLoading(false);
-    stopRecognition();
-    hasStartedRef.current = true;
-    fetchNext("START");
-  };
+  // const restartInterview = () => {
+  //   setResponses([]);
+  //   setQuestions([]);
+  //   setCurrentIndex(0);
+  //   setShowTextarea(false);
+  //   setFeedbackList([]);
+  //   setCompleted(false);
+  //   setElapsedTime(0);
+  //   setLoading(false);
+  //   stopRecognition();
+  //   hasStartedRef.current = true;
+  //   fetchNext("START");
+  // };
 
   const exportToPDF = () => {
     const doc = new jsPDF();
@@ -357,7 +363,7 @@ export default function MockInterview() {
             </div>
 
             <div className="flex flex-wrap gap-4 justify-end">
-              <Button onClick={restartInterview} className="bg-gray-200 hover:bg-gray-300 text-gray-800">Restart Interview</Button>
+              {/* <Button onClick={restartInterview} className="bg-gray-200 hover:bg-gray-300 text-gray-800">Restart Interview</Button> */}
               <Button onClick={() => navigate("/interview-job-description")} className="bg-[#f3e5f5] hover:bg-[#e1bee7] text-[#6a1b9a]">Change Job Description</Button>
               <Button onClick={exportToPDF} className="bg-[#ce93d8] hover:bg-[#ba68c8] text-white">Export as PDF</Button>
             </div>


### PR DESCRIPTION
This commit introduces dynamic configuration for the number of interview questions. The number of questions is now derived from the `RunnableConfig` instead of being hardcoded. Additionally, the frontend now stores and uses this value to determine the last question in the interview flow. 